### PR TITLE
Syntax error in curl command for classifying text (missing dash)

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -84,7 +84,7 @@ Now that the classifier is trained, you can query it.
 1.  Classify some weather-related questions to review how your newly trained classifier responds. Here is an example call. Replace `{username}`, `{password}`, and `{classifier_id}` with your information:
 
     ```bash
-    curl -G -user "{username}":"{password}" "https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/{classifier_id}/classify" --data-urlencode "text=How hot will it be today?"
+    curl -G --user "{username}":"{password}" "https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/{classifier_id}/classify" --data-urlencode "text=How hot will it be today?"
     ```
     {: pre}
 


### PR DESCRIPTION
Missing dash in the curl command: "-user" should be "--user".

Current, failing, syntax (returns prompt for a user named "ser")
`$ curl -G -user "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx":"xxxxxxxxxxxx" "https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/359f3fx202-nlc-125950/classify" --data-urlencode "text=How hot will it be today?"`
`Enter host password for user 'ser':`

Correct syntax (double dash)
`curl -G --user "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx":"xxxxxxxxxxxx" "https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/359f3fx202-nlc-125950/classify" --data-urlencode "text=How hot will it be today?"` 
```
{
  "classifier_id" : "359f3fx202-nlc-125950",
  "url" : "https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/359f3fx202-nlc-125950",
  "text" : "How hot will it be today?",
  "top_class" : "temperature",
  "classes" : [ {
    "class_name" : "temperature",
    "confidence" : 0.993097742655515
  }, {
    "class_name" : "conditions",
    "confidence" : 0.006902257344485079
  } ]
}
```