### PR TITLE
Fix link and syntax

### DIFF
--- a/using-your-data.md
+++ b/using-your-data.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-07-17"
+lastupdated: "2017-07-18"
 
 ---
 
@@ -10,7 +10,7 @@ lastupdated: "2017-07-17"
 {:shortdesc: .shortdesc}
 
 # Using your own data
-After you create, train, and query an {{site.data.keyword.nlclassifierfull}} with the data in the [Getting started](/doc/natural-language-classifier/getting-started.html) example, you will want to create a classifier that works with your own data. You assemble and provide this training data.
+After you create, train, and query an {{site.data.keyword.nlclassifierfull}} with the data in the [Getting started](/docs/services/natural-language-classifier/getting-started.html) example, you will want to create a classifier that works with your own data. You assemble and provide this training data.
 {:shortdesc}
 
 ## Structure of training data
@@ -38,16 +38,16 @@ Make sure that your CSV training data adheres to the following format requiremen
 - Class values cannot include tabs or end-of-line characters.
 - Text values cannot contain tabs or new lines without special handling. To preserve tabs or new lines, escape a tab with `\t`, and escape new lines with `\r`, `\n` or `\r\n`.
 
-	For example, `Example text\twith a tab` is valid, but `Example text    with a tab` is not valid.
+    For example, `Example text\twith a tab` is valid, but <code>Example text&nbsp;&nbsp;&nbsp;&nbsp;with a tab</code> is not valid.
 - Always enclose text or class values with double quotation marks in the training data when it includes the following characters:
-	- Commas: `"Example text, with comma"`.
-	- Double quotation marks. In addition, quotation marks must be escaped with double quotation marks: `"Example text with ""quotation"""`.
+    - Commas: `"Example text, with comma"`.
+    - Double quotation marks. In addition, quotation marks must be escaped with double quotation marks: `"Example text with ""quotation"""`.
 
 ## Size limitations
 There are both minimum and maximum limits to the training data:
 
--   The training data must have at least five records (rows) and no more than 15,000 records.
--   The maximum total length of a text value is 1024 characters.
+- The training data must have at least five records (rows) and no more than 15,000 records.
+- The maximum total length of a text value is 1024 characters.
 
 ## Languages
 Although the default language is English, you can specify the language of the training data when you create the classifier. The language of the training data must match the language of the text that you intend to classify. For details, see the [API reference ![External link icon](../../icons/launch-glyph.svg "External link icon")](http://www.ibm.com/watson/developercloud/natural-language-classifier/api/v1/){:new_window}.
@@ -61,13 +61,13 @@ The following guidelines are not enforced by the API. However, the classifier te
 - Limit the number of classes to several hundred classes. Support for larger numbers of classes might be included in later versions of the service.
 - Make sure that each class is matched with at least 5 - 10 records when each text record has only one class. This number provides enough training on that class.
 - Evaluate the need for multiple classes. Two common reasons drive multiple classes:
-	- When the text is vague, identifying a single class is not always clear.
-	- When experts interpret the text in different ways, multiple classes support those interpretations.
+    - When the text is vague, identifying a single class is not always clear.
+    - When experts interpret the text in different ways, multiple classes support those interpretations.
 
-	However, if many texts in your training data include multiple classes, or if some texts have more than three classes, you might need to refine the classes. For example, review whether the classes are hierarchical. If they are hierarchical, include the leaf node as the class.
--  Include standard hyphenated terms when they are part of the training data (`back-to-back` or ` part-time job`).
+    However, if many texts in your training data include multiple classes, or if some texts have more than three classes, you might need to refine the classes. For example, review whether the classes are hierarchical. If they are hierarchical, include the leaf node as the class.
+- Include standard hyphenated terms when they are part of the training data (`back-to-back` or ` part-time job`).
 
-	However, don't connect adjacent words to create new terms not found in the language of the training data. For example, instead of defining `dish-ran-away` or `with_the_spoon`, define the relevant phrases as separate words (`dish ran away` and `with the spoon`) with the appropriate class.
+    However, don't connect adjacent words to create new terms not found in the language of the training data. For example, instead of defining `dish-ran-away` or `with_the_spoon`, define the relevant phrases as separate words (`dish ran away` and `with the spoon`) with the appropriate class.
 
 ## Constructing training data
 Machine learning describes a process of learning some properties from a set of data and then applying the properties to new data. The {{site.data.keyword.nlclassifiershort}} service follows this process. It is trained to connect predefined classes to example texts and then applies those classes to new inputs.


### PR DESCRIPTION
- internal link was missing `services` and had `/doc`, not `/docs`.
- non breaking spaces were not rendering in markdown code phrase. Changed to HTML
- removed tabs and fixed indentation.