### PR TITLE
Revert "Change Access the beta toolkit to Open Tool"

### DIFF
--- a/tool-overview.md
+++ b/tool-overview.md
@@ -32,7 +32,7 @@ To find the link to the toolkit, follow these steps to get to your {{site.data.k
 1.  Open your {{site.data.keyword.nlclassifiershort}} service tile by logging into your [{{site.data.keyword.Bluemix_notm}} Dashboard ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://console.{DomainName}/dashboard/services){: new_window}.
 
     - In the **Services** area, click your {{site.data.keyword.nlclassifiershort}} service tile to open the instance dashboard. (If you don't have a service tile, [create an instance ![External link icon](../../icons/launch-glyph.svg)](https://console.{DomainName}/catalog/services/natural-language-classifier/){: new_window} of the {{site.data.keyword.nlclassifiershort}} service.)
-1.  In the service dashboard, click **Open Tool**.
+1.  In the service dashboard, click **Access the beta toolkit**.
 
     Bookmark the URL for easy access to the toolkit later.
     {: tip}


### PR DESCRIPTION
Reverts IBM-Bluemix-Docs/natural-language-classifier#18

New manage page has not been deployed yet